### PR TITLE
Scope options for useMolecule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ["10.x", "12.x", "14.x"]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: ["16.x"]
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-05-31
+
+- Added options for overriding scope in `useMolecule`. This removes the need for `ScopeProvider` in a number of cases.
+
 ## [1.0.3] - 2022-04-08
 
 - Improve performance when using thousands of molecules
@@ -31,7 +35,8 @@ Initial release of `jotai-molecules`
 - `createScope` for creating a scope for molecules
 - `ScopeProvider` a React component for providing scope to the tree
 
-[unreleased]: https://github.com/saasquatch/jotai-molecules/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/saasquatch/jotai-molecules/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/saasquatch/jotai-molecules/releases/tag/v1.1.0
 [1.0.3]: https://github.com/saasquatch/jotai-molecules/releases/tag/v1.0.3
 [1.0.2]: https://github.com/saasquatch/jotai-molecules/releases/tag/v1.0.2
 [1.0.1]: https://github.com/saasquatch/jotai-molecules/releases/tag/v1.0.1

--- a/README.md
+++ b/README.md
@@ -342,6 +342,30 @@ export const PageComponent = () => {
 };
 ```
 
+By default `useMolecule` will provide a molecule based off the _implicit_ scope from context. You can override this behaviour by passing options to `useMolecule`.
+
+- `withScope` - will overide a scope value (`ScopeTuple<unknown>`)
+- `withUniqueScope` - will override a scope value with a new unique value (`MoleculeScope<unknown>`)
+- `exclusiveScope` - will override ALL scopes (`ScopeTuple<unknown>`)
+
+Instead of a scope provider, you can use an explicit scope when using a molecule. This can simplify integrating jotai with other hooks-based libraries.
+
+**Before:**
+
+```tsx
+const App = () => (
+  <ScopeProvider scope={UserScope} value={"sam@example.com"}>
+    <UserComponent />
+  </ScopeProvider>
+);
+```
+
+**After:**
+
+```tsx
+useMolecule(UserMolecule, { withScope: [UserScope, "sam@example.com"] });
+```
+
 ### createScope
 
 Creates a reference for scopes, similar to React Context

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jotai-molecules",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jotai-molecules",
   "description": "A tiny, fast, dependency-free 1.18kb library for creating jotai atoms in a way that lets you lift state up, or push state down.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/jotai-molecules.esm.js",

--- a/src/ScopeProvider.test.tsx
+++ b/src/ScopeProvider.test.tsx
@@ -1,13 +1,11 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import { atom, useAtom } from "jotai";
 import React, { useContext, useState } from "react";
+import { ScopeCacheContext } from "./contexts/ScopeCacheContext";
+import { ScopeContext } from "./contexts/ScopeContext";
 import { molecule } from "./molecule";
 import { createScope } from "./scope";
-import {
-  ScopeProvider,
-  ScopeCacheContext,
-  ScopeContext,
-} from "./ScopeProvider";
+import { ScopeProvider } from "./ScopeProvider";
 import { useMolecule } from "./useMolecule";
 
 const ExampleMolecule = molecule(() => {
@@ -16,11 +14,11 @@ const ExampleMolecule = molecule(() => {
   };
 });
 
-const UserScope = createScope("user@example.com");
+export const UserScope = createScope("user@example.com");
 
 const AtomScope = createScope(atom("user@example.com"));
 
-const UserMolecule = molecule((_, getScope) => {
+export const UserMolecule = molecule((_, getScope) => {
   const userId = getScope(UserScope);
 
   return {

--- a/src/ScopeProvider.tsx
+++ b/src/ScopeProvider.tsx
@@ -1,35 +1,7 @@
-import React, { useContext, useEffect, useMemo } from "react";
-import { ScopeTuple } from "./molecule";
+import React from "react";
+import { ScopeContext } from "./contexts/ScopeContext";
 import { MoleculeScope } from "./scope";
-import { createStore } from "./store";
-import { createMemoizeAtom } from "./weakCache";
-
-export const StoreContext = React.createContext(createStore());
-StoreContext.displayName = "JotaiMoleculeStoreContext";
-
-export const ScopeContext = React.createContext<ScopeTuple<unknown>[]>([]);
-ScopeContext.displayName = "JotaiMoleculeScopeContext";
-
-export const ScopeCacheContext = React.createContext<PrimitiveScopeMap>(
-  new WeakMap()
-);
-ScopeCacheContext.displayName = "JotaiMoleculeScopeCacheContext";
-
-type PrimitiveScopeMap = WeakMap<
-  AnyMoleculeScope,
-  Map<AnyScopeValue, TupleAndReferences>
->;
-
-type TupleAndReferences = {
-  references: Set<Symbol>;
-  tuple: AnyScopeTuple;
-};
-
-const memoize = createMemoizeAtom();
-
-type AnyMoleculeScope = MoleculeScope<unknown>;
-type AnyScopeValue = unknown;
-type AnyScopeTuple = ScopeTuple<unknown>;
+import { MoleculeScopeOptions, useScopes } from "./useScopes";
 
 export type ProviderProps<T> = {
   scope: MoleculeScope<T>;
@@ -48,143 +20,22 @@ export type ProviderProps<T> = {
  *
  */
 export function ScopeProvider<T>(props: ProviderProps<T>) {
-  const { value: providedValue, scope, uniqueValue } = props;
+  const { value, scope, uniqueValue } = props;
 
-  if (typeof providedValue !== "undefined" && uniqueValue)
-    throw new Error("Provide one of `value` or `uniqueValue` but not both");
-
-  const generatedValue = useMemo(
-    () => new Error("Do not use this scope value. It is a placeholder only."),
-    []
-  );
-  const value = providedValue ?? generatedValue;
-
-  const memoizedTuple = useMemoizedScopeTuple<T>(scope, value);
-  const parentScopes = useContext(ScopeContext);
-
-  const found = parentScopes.findIndex((scopeTuple) => {
-    const scope = scopeTuple[0];
-    return scope === props.scope;
-  });
-
-  const downstreamScopes =
-    found >= 0
-      ? // Replace inline (when found)
-        [
-          ...parentScopes.slice(0, found),
-          memoizedTuple,
-          ...parentScopes.slice(found + 1),
-        ]
-      : // Append to the end (when not found)
-        [...parentScopes, memoizedTuple];
+  let options: MoleculeScopeOptions;
+  if (uniqueValue) {
+    options = {
+      withUniqueScope: scope,
+    };
+  } else {
+    options = {
+      withScope: [scope, value],
+    };
+  }
+  const downstreamScopes = useScopes(options);
   return (
     <ScopeContext.Provider value={downstreamScopes}>
       {props.children}
     </ScopeContext.Provider>
   );
-}
-
-function useMemoizedScopeTuple<T>(
-  scope: MoleculeScope<T>,
-  value: Error | NonNullable<T>
-) {
-  const id = useMemo(() => Symbol(Math.random()), []);
-  const primitiveScopeMap = useContext(ScopeCacheContext);
-  useEffect(() => {
-    return () => {
-      // Clean up scope value, if cached
-      // Deleting the scope tuple should cascade a cleanup
-      // 1 - it is deleted from this map
-      // 2 - it should be garbage collected from the Molecule store WeakMap
-      // 3 - any atoms created in the molecule should be garbage collected
-      // 4 - any atom values in the jotai store should be garbage collected from it's WeakMap
-      deregisterScopeTuple<T>(primitiveScopeMap, scope, value, id);
-    };
-  }, [scope, value, primitiveScopeMap, id]);
-
-  /**
-   * Memoization is important since the store relies
-   * on the ScopeTuple being referentially consistent
-   *
-   * If a new array is provided to the store,
-   * then new molecules are created
-   */
-  const memoizedTuple = useMemo<ScopeTuple<T>>(
-    () =>
-      registerMemoizedScopeTuple<T>(scope, value as T, primitiveScopeMap, id),
-    [scope, value, primitiveScopeMap, id]
-  );
-  return memoizedTuple;
-}
-
-/**
- * For values that are "primitive" (not an object),
- * deregisters them from the primitive scope
- * cache to ensure no memory leaks
- */
-function deregisterScopeTuple<T>(
-  primitiveScopeMap: PrimitiveScopeMap,
-  scope: MoleculeScope<T>,
-  value: Error | NonNullable<T>,
-  id: Symbol
-) {
-  // No scope cleanup needed for non-primitives
-  if (typeof value === "object") return;
-
-  const scopeMap = primitiveScopeMap.get(scope);
-  if (!scopeMap) return;
-
-  const cached = scopeMap.get(value);
-  if (!cached) return;
-
-  cached.references.delete(id);
-
-  if (cached.references.size <= 0) {
-    scopeMap.delete(value);
-  }
-}
-
-/**
- * Creates a memoized tuple of `[scope,value]`
- *
- * Registers primitive `value`s in the primitive scope cache. This has side-effects
- * and needs to be cleaned up with `deregisterScopeTuple`
- *
- */
-function registerMemoizedScopeTuple<T>(
-  scope: MoleculeScope<T>,
-  value: T,
-  primitiveMap: PrimitiveScopeMap,
-  id: Symbol
-) {
-  const tuple: ScopeTuple<T> = [scope, value];
-  if (typeof value === "object") {
-    // If we have an object, we can safely weak cache it.
-    // Equivalent to `cache.get(scope).get(value)`
-    return memoize(() => tuple, [scope, value as unknown as object]);
-  }
-
-  // Not an object, so we can't safely cache it in a WeakMap
-  let valuesForScope = primitiveMap.get(scope);
-  if (!valuesForScope) {
-    valuesForScope = new Map();
-    primitiveMap.set(scope, valuesForScope);
-  }
-
-  let cached = valuesForScope.get(value);
-  if (cached) {
-    // Increment references
-    cached.references.add(id);
-
-    return cached.tuple as ScopeTuple<T>;
-  }
-
-  const references = new Set<Symbol>();
-  references.add(id);
-  valuesForScope.set(value, {
-    references,
-    tuple,
-  });
-
-  return tuple;
 }

--- a/src/contexts/ScopeCacheContext.tsx
+++ b/src/contexts/ScopeCacheContext.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { PrimitiveScopeMap } from "../types";
+
+export const ScopeCacheContext = React.createContext<PrimitiveScopeMap>(
+  new WeakMap()
+);
+ScopeCacheContext.displayName = "JotaiMoleculeScopeCacheContext";

--- a/src/contexts/ScopeContext.tsx
+++ b/src/contexts/ScopeContext.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import type { ScopeTuple } from "../types";
+
+export const ScopeContext = React.createContext<ScopeTuple<unknown>[]>([]);
+ScopeContext.displayName = "JotaiMoleculeScopeContext";

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { createStore } from "../store";
+
+export const StoreContext = React.createContext(createStore());
+StoreContext.displayName = "JotaiMoleculeStoreContext";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,12 @@
 import { molecule } from "./molecule";
 import { createScope } from "./scope";
-
 import { ScopeProvider } from "./ScopeProvider";
 import { useMolecule } from "./useMolecule";
-
-export { molecule, createScope, ScopeProvider, useMolecule };
+import { MoleculeScopeOptions } from "./useScopes";
+export {
+  molecule,
+  createScope,
+  ScopeProvider,
+  useMolecule,
+  MoleculeScopeOptions,
+};

--- a/src/molecule.ts
+++ b/src/molecule.ts
@@ -1,7 +1,5 @@
 import { MoleculeScope } from "./scope";
 
-export type ScopeTuple<T> = [MoleculeScope<T>, T];
-
 export type ScopeGetter = {
   <Value>(scope: MoleculeScope<Value>): Value;
 };

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,11 +1,8 @@
 import { atom, PrimitiveAtom } from "jotai";
-import {
-  Molecule,
-  molecule,
-  ScopeTuple,
-} from "./molecule";
+import { Molecule, molecule } from "./molecule";
 import { createStore } from "./store";
 import { createScope } from "./scope";
+import { ScopeTuple } from "./types";
 
 type BaseAtoms = {
   nameAtom: PrimitiveAtom<string>;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
-import { Molecule, MoleculeGetter, ScopeGetter, ScopeTuple } from "./molecule";
+import { Molecule, MoleculeGetter, ScopeGetter } from "./molecule";
 import { MoleculeScope } from "./scope";
+import { ScopeTuple } from "./types";
 import { createMemoizeAtom } from "./weakCache";
 
 type Deps = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+import type { MoleculeScope } from "./scope";
+import type { TupleAndReferences } from "./useMemoizedScopeTuple";
+
+export type ScopeTuple<T> = [MoleculeScope<T>, T];
+
+export type PrimitiveScopeMap = WeakMap<
+  AnyMoleculeScope,
+  Map<AnyScopeValue, TupleAndReferences>
+>;
+type AnyMoleculeScope = MoleculeScope<unknown>;
+type AnyScopeValue = unknown;
+export type AnyScopeTuple = ScopeTuple<unknown>;

--- a/src/useMemoizedScopeTuple.tsx
+++ b/src/useMemoizedScopeTuple.tsx
@@ -1,0 +1,119 @@
+import { useContext, useEffect, useMemo } from "react";
+import { ScopeCacheContext } from "./contexts/ScopeCacheContext";
+import { AnyScopeTuple, PrimitiveScopeMap, ScopeTuple } from "./types";
+import { createMemoizeAtom } from "./weakCache";
+
+export type TupleAndReferences = {
+  references: Set<Symbol>;
+  tuple: AnyScopeTuple;
+};
+
+const memoize = createMemoizeAtom();
+
+/**
+ * Scope tuples need to be memozied as their array to be used in the store.
+ *
+ * This hook will memoize the tuple in the ScopeCacheContext
+ *
+ * @returns
+ */
+export function useMemoizedScopeTuple<T>(tuple?: ScopeTuple<T>): ScopeTuple<T> {
+  const id = useMemo(() => Symbol(Math.random()), []);
+  const primitiveScopeMap = useContext(ScopeCacheContext);
+  const [scope, value] = tuple ?? [];
+  useEffect(() => {
+    return () => {
+      if (!tuple) return;
+      // Clean up scope value, if cached
+      // Deleting the scope tuple should cascade a cleanup
+      // 1 - it is deleted from this map
+      // 2 - it should be garbage collected from the Molecule store WeakMap
+      // 3 - any atoms created in the molecule should be garbage collected
+      // 4 - any atom values in the jotai store should be garbage collected from it's WeakMap
+      deregisterScopeTuple<T>(tuple, primitiveScopeMap, id);
+    };
+  }, [scope, value, primitiveScopeMap, id]);
+
+  /**
+   * Memoization is important since the store relies
+   * on the ScopeTuple being referentially consistent
+   *
+   * If a new array is provided to the store,
+   * then new molecules are created
+   */
+  const memoizedTuple = useMemo<ScopeTuple<T>>(() => {
+    if (!tuple) return [undefined, undefined] as unknown as ScopeTuple<T>;
+    return registerMemoizedScopeTuple<T>(tuple, primitiveScopeMap, id);
+  }, [scope, value, primitiveScopeMap, id]);
+  return memoizedTuple;
+}
+
+/**
+ * For values that are "primitive" (not an object),
+ * deregisters them from the primitive scope
+ * cache to ensure no memory leaks
+ */
+export function deregisterScopeTuple<T>(
+  tuple: ScopeTuple<T>,
+  primitiveScopeMap: PrimitiveScopeMap,
+  id: Symbol
+) {
+  const [scope, value] = tuple;
+  // No scope cleanup needed for non-primitives
+  if (typeof value === "object") return;
+
+  const scopeMap = primitiveScopeMap.get(scope);
+  if (!scopeMap) return;
+
+  const cached = scopeMap.get(value);
+  if (!cached) return;
+
+  cached.references.delete(id);
+
+  if (cached.references.size <= 0) {
+    scopeMap.delete(value);
+  }
+}
+
+/**
+ * Creates a memoized tuple of `[scope,value]`
+ *
+ * Registers primitive `value`s in the primitive scope cache. This has side-effects
+ * and needs to be cleaned up with `deregisterScopeTuple`
+ *
+ */
+export function registerMemoizedScopeTuple<T>(
+  tuple: ScopeTuple<T>,
+  primitiveMap: PrimitiveScopeMap,
+  id: Symbol
+): ScopeTuple<T> {
+  const [scope, value] = tuple;
+  if (typeof value === "object") {
+    // If we have an object, we can safely weak cache it.
+    // Equivalent to `cache.get(scope).get(value)`
+    return memoize(() => tuple, [scope, value as unknown as object]);
+  }
+
+  // Not an object, so we can't safely cache it in a WeakMap
+  let valuesForScope = primitiveMap.get(scope);
+  if (!valuesForScope) {
+    valuesForScope = new Map();
+    primitiveMap.set(scope, valuesForScope);
+  }
+
+  let cached = valuesForScope.get(value);
+  if (cached) {
+    // Increment references
+    cached.references.add(id);
+    return cached.tuple as ScopeTuple<T>;
+  }
+
+  const references = new Set<Symbol>();
+  references.add(id);
+  valuesForScope.set(value, {
+    references,
+    tuple,
+  });
+
+  return tuple;
+}

--- a/src/useMolecule.test.tsx
+++ b/src/useMolecule.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React, { useContext } from "react";
+import { ScopeContext } from "./contexts/ScopeContext";
+import { ScopeProvider } from "./ScopeProvider";
+import { UserMolecule, UserScope } from "./ScopeProvider.test";
+import { useMolecule } from "./useMolecule";
+
+describe("useMolecule", () => {
+  test("Use molecule can have scope provided", () => {
+    const useUserMolecule = () => {
+      return {
+        molecule: useMolecule(UserMolecule, {
+          withScope: [UserScope, "jeffrey@example.com"],
+        }),
+      };
+    };
+    const { result } = renderHook(useUserMolecule, {});
+
+    expect(result.current.molecule.userId).toBe("jeffrey@example.com");
+  });
+  test("Exclusive scope ignores wrappers scope", () => {
+    const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <ScopeProvider scope={UserScope} value={"sam@example.com"}>
+        {children}
+      </ScopeProvider>
+    );
+
+    const useUserMolecule = () => {
+      return {
+        molecule: useMolecule(UserMolecule, {
+          withScope: [UserScope, "jeffrey@example.com"],
+        }),
+        context: useContext(ScopeContext),
+      };
+    };
+    const { result } = renderHook(useUserMolecule, {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.context).toStrictEqual([
+      [UserScope, "sam@example.com"],
+    ]);
+    expect(result.current.molecule.userId).toBe("jeffrey@example.com");
+  });
+  test("Unique scope will generate a new value for each use", () => {
+    const useUserMolecule = () => {
+      return {
+        molecule1: useMolecule(UserMolecule, {
+          withUniqueScope: UserScope,
+        }),
+        molecule2: useMolecule(UserMolecule, {
+          withUniqueScope: UserScope,
+        }),
+      };
+    };
+    const { result } = renderHook(useUserMolecule, {});
+
+    expect(result.current.molecule1.userId).not.toBe(
+      result.current.molecule2.userId
+    );
+  });
+});

--- a/src/useMolecule.tsx
+++ b/src/useMolecule.tsx
@@ -1,10 +1,12 @@
-import { useContext } from "react";
 import { Molecule } from "./molecule";
-import { StoreContext, ScopeContext } from "./ScopeProvider";
+import { MoleculeScopeOptions, useScopes } from "./useScopes";
+import { useStore } from "./useStore";
 
-
-export function useMolecule<T>(m: Molecule<T>): T {
-  const store = useContext(StoreContext);
-  const scopes = useContext(ScopeContext);
+export function useMolecule<T>(
+  m: Molecule<T>,
+  options?: MoleculeScopeOptions
+): T {
+  const scopes = useScopes(options);
+  const store = useStore();
   return store.get(m, ...scopes);
 }

--- a/src/useScopes.tsx
+++ b/src/useScopes.tsx
@@ -9,9 +9,6 @@ export function useScopes(
 ): ScopeTuple<unknown>[] {
   const parentScopes = useContext(ScopeContext);
 
-  // if (typeof providedValue !== "undefined" && uniqueValue)
-  //   throw new Error("Provide one of `value` or `uniqueValue` but not both");
-
   const generatedValue = useMemo(
     () => new Error("Do not use this scope value. It is a placeholder only."),
     []

--- a/src/useScopes.tsx
+++ b/src/useScopes.tsx
@@ -4,7 +4,9 @@ import { MoleculeScope } from "./scope";
 import { ScopeTuple } from "./types";
 import { useMemoizedScopeTuple } from "./useMemoizedScopeTuple";
 
-export function useScopes(options?: MoleculeScopeOptions) {
+export function useScopes(
+  options?: MoleculeScopeOptions
+): ScopeTuple<unknown>[] {
   const parentScopes = useContext(ScopeContext);
 
   // if (typeof providedValue !== "undefined" && uniqueValue)
@@ -18,7 +20,7 @@ export function useScopes(options?: MoleculeScopeOptions) {
   const tuple: ScopeTuple<unknown> | undefined = (() => {
     if (!options) return undefined;
     if (options.withUniqueScope) {
-      return [options.withUniqueScope, generatedValue];
+      return [options.withUniqueScope, generatedValue] as ScopeTuple<unknown>;
     }
     if (options.withScope) {
       return options.withScope;

--- a/src/useScopes.tsx
+++ b/src/useScopes.tsx
@@ -1,0 +1,74 @@
+import { useContext, useMemo } from "react";
+import { ScopeContext } from "./contexts/ScopeContext";
+import { MoleculeScope } from "./scope";
+import { ScopeTuple } from "./types";
+import { useMemoizedScopeTuple } from "./useMemoizedScopeTuple";
+
+export function useScopes(options?: MoleculeScopeOptions) {
+  const parentScopes = useContext(ScopeContext);
+
+  // if (typeof providedValue !== "undefined" && uniqueValue)
+  //   throw new Error("Provide one of `value` or `uniqueValue` but not both");
+
+  const generatedValue = useMemo(
+    () => new Error("Do not use this scope value. It is a placeholder only."),
+    []
+  );
+
+  const tuple: ScopeTuple<unknown> | undefined = (() => {
+    if (!options) return undefined;
+    if (options.withUniqueScope) {
+      return [options.withUniqueScope, generatedValue];
+    }
+    if (options.withScope) {
+      return options.withScope;
+    }
+    if (options.exclusiveScope) {
+      return options.exclusiveScope;
+    }
+    return undefined;
+  })();
+
+  const memoizedTuple = useMemoizedScopeTuple(tuple);
+
+  if (options?.exclusiveScope) {
+    /**
+     *  Exclusive scopes means ignore scopes from context
+     */
+    return [options.exclusiveScope];
+  }
+  if (!tuple) {
+    /**
+     * This is the default case, when we don't have any tuples
+     */
+    return parentScopes;
+  }
+
+  const [scope] = tuple;
+  const found = parentScopes.findIndex((scopeTuple) => {
+    const foundScope = scopeTuple[0];
+    return foundScope === scope;
+  });
+
+  const downstreamScopes =
+    found >= 0
+      ? // Replace inline (when found)
+        [
+          ...parentScopes.slice(0, found),
+          memoizedTuple,
+          ...parentScopes.slice(found + 1),
+        ]
+      : // Append to the end (when not found)
+        [...parentScopes, memoizedTuple];
+
+  return downstreamScopes;
+}
+
+export type MoleculeScopeOptions = {
+  /**
+   * By default {@link useMolecule} will use scopes based on the {@link ScopeContext}
+   */
+  withScope?: ScopeTuple<unknown>;
+  withUniqueScope?: MoleculeScope<unknown>;
+  exclusiveScope?: ScopeTuple<unknown>;
+};

--- a/src/useStore.tsx
+++ b/src/useStore.tsx
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { StoreContext } from "./contexts/StoreContext";
+
+export function useStore() {
+  return useContext(StoreContext);
+}


### PR DESCRIPTION
Adds scope options so that useMolecule can be called with explicit scope (via a prop), instead of only via implicit scope (via context)

```js
useMolecule(UserMolecule, {
    withScope: [UserScope, "jeffrey@example.com"],
})
```

Instead of 
```jsx
<ScopeProvider scope={UserScope} value="jeffrey@example.com">
```
and
```js
useMolecule(UserMolecule)
```